### PR TITLE
Changed regular expression match for extensions to insert '$'

### DIFF
--- a/asciidoc_plugin.rb
+++ b/asciidoc_plugin.rb
@@ -43,9 +43,9 @@ module Jekyll
         end
         @setup = true
       end
-      
+
       def matches(ext)
-        rgx = '(' + @config['asciidoc_ext'].gsub(',','|') +')'
+        rgx = '(' + @config['asciidoc_ext'].gsub(',','$|') +'$)'
         ext =~ Regexp.new(rgx, Regexp::IGNORECASE)
       end
 


### PR DESCRIPTION
This fix addresses the issue by anchoring the match for extensions like
'ad' to the end of the line, preventing it from matching files like
.jade.
