### PR TITLE
Set version to 1.0.0 (remove prerelease text)

### DIFF
--- a/jekyll-asciidoc.gemspec
+++ b/jekyll-asciidoc.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'jekyll-asciidoc'
-  s.version = '1.0.0.alpha.1'
+  s.version = '1.0.0'
   s.summary = 'A Jekyll plugin that converts AsciiDoc files in your site source to HTML pages using Asciidoctor.'
   s.description = 'A Jekyll plugin that converts AsciiDoc files in your site source to HTML pages using Asciidoctor.'
   s.authors = ['Dan Allen']


### PR DESCRIPTION
This will enable the gem to be installed from Rubygems via `gem install jekyll-asciidoc` (per the instructions in the README) without having to specify the `--pre` flag. Since we are releasing this as a gem for production use, seems that v.1.0.0 is appropriate. WDYT? Once this is done I will re-publish the gem to Rubygems.