### PR TITLE
Add rake dependency to gemspec

### DIFF
--- a/jekyll-asciidoc.gemspec
+++ b/jekyll-asciidoc.gemspec
@@ -17,5 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'asciidoctor', '>= 0.1.4'
+
+  s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'jekyll', '> 1.0.0'
 end


### PR DESCRIPTION
Bundler complains when running `bundle exec rake` without rake in gemspec/Gemfile.