### PR TITLE
resolves #55 align environment-related attributes with other site generators

### DIFF
--- a/lib/jekyll-asciidoc.rb
+++ b/lib/jekyll-asciidoc.rb
@@ -21,7 +21,7 @@ module Jekyll
           asciidoctor_config[:safe] ||= 'safe'
           (asciidoctor_config[:attributes] ||= []).tap do |attributes|
             attributes.unshift(*['notitle', 'hardbreaks', 'idprefix', 'idseparator=-', 'linkattrs'])
-            attributes.push('env-jekyll')
+            attributes.push('env=site', 'env-site', 'site-gen=jekyll', 'site-gen-jekyll', 'jekyll-version=' + Jekyll::VERSION)
           end
           asciidoctor_config.freeze
         end


### PR DESCRIPTION
* use env=site and env-site instead of env-jekyll
* introduce site-gen=jekyll and site-gen-jekyll
* define jekyll-version attribute