### PR TITLE
resolves #65 disable Liquid preprocessor on AsciiDoc files by default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,7 @@ endif::[]
 :uri-gem-jekyll-asciidoc: http://rubygems.org/gems/jekyll-asciidoc
 :uri-jekyll: https://jekyllrb.com
 :uri-front-matter: http://jekyllrb.com/docs/frontmatter/
+:uri-liquid-templates: https://jekyllrb.com/docs/templates/
 :uri-graphviz: http://www.graphviz.org
 
 ifdef::status[]
@@ -162,6 +163,13 @@ In addition to these explicit page attributes, the following AsciiDoc attributes
 * doctitle (i.e., the document title) (becomes title)
 * author
 * revdate (becomes date; value is converted to a DateTime object; only for posts)
+
+Unlike other content files, the {uri-liquid-templates}[Liquid template preprocessor] is not applied to AsciiDoc files by default (as of v1.2.0 of this plugin).
+If you want the Liquid template preprocessor to be applied to an AsciiDoc file (prior to the content being passed to the AsciiDoc processor), you must enable it by setting the liquid page variable.
+
+----
+:page-liquid:
+----
 
 IMPORTANT: Each AsciiDoc file must begin with a {uri-front-matter}[front matter header].
 Otherwise, Jekyll won't treat the file as a page, but rather as a static file.

--- a/lib/jekyll-asciidoc.rb
+++ b/lib/jekyll-asciidoc.rb
@@ -86,6 +86,12 @@ module Jekyll
   module Generators
     # Promotes select AsciiDoc attributes to Jekyll front matter
     class AsciiDocPreprocessor < Generator
+      module NoLiquid
+        def render_with_liquid?
+          false
+        end
+      end
+
       def generate(site)
         asciidoc_converter = JEKYLL_MIN_VERSION_3 ?
             site.find_converter_instance(Jekyll::Converters::AsciiDocConverter) :
@@ -110,6 +116,8 @@ module Jekyll
             end
 
             page.data['layout'] = 'default' unless page.data.key? 'layout'
+
+            page.extend NoLiquid unless page.data['liquid']
           end
         end
 
@@ -128,6 +136,8 @@ module Jekyll
             end
 
             post.data['layout'] = 'post' unless post.data.key? 'layout'
+
+            post.extend NoLiquid unless post.data['liquid']
           end
         end
       end


### PR DESCRIPTION
- disable Liquid preprocessor on AsciiDoc files by default
- allow Liquid preprocessor to be enabled by setting the liquid page variable
