### PR TITLE
resolves #76 document minimum version of Jekyll

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,7 +32,7 @@ ifdef::status[]
 image:https://img.shields.io/gem/v/jekyll-asciidoc.svg?label=gem%20version[Gem Version, link={uri-gem-jekyll-asciidoc}]
 endif::[]
 
-A plugin for {uri-jekyll}[Jekyll] that converts {uri-asciidoc}[AsciiDoc] files in your site source to HTML pages using {uri-asciidoctor}[Asciidoctor].
+A plugin for {uri-jekyll}[Jekyll] (>= 2.0.0) that converts {uri-asciidoc}[AsciiDoc] files in your site source to HTML pages using {uri-asciidoctor}[Asciidoctor].
 
 == Overview
 

--- a/jekyll-asciidoc.gemspec
+++ b/jekyll-asciidoc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'asciidoctor', '>= 0.1.4'
+  s.add_runtime_dependency 'jekyll', '>= 2.0.0'
 
-  s.add_development_dependency 'rake', '~> 10.0'
-  s.add_development_dependency 'jekyll', '> 1.0.0'
+  s.add_development_dependency 'rake'
 end


### PR DESCRIPTION
- document minimum version of Jekyll as 2.0.0
- make jekyll gem a runtime dependency (so we can enforce minimum version)
- remove version of rake gem