### PR TITLE
resolves #69 disable hard line breaks by default

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -259,25 +259,37 @@ To pass additional attributes to AsciiDoc, or override the default attributes de
 ----
 asciidoctor:
   attributes:
-    - hardbreaks!
+    - idprefix=_
     - source-highlighter=pygments
     - pygments-css=style
 ----
 
-=== Disabling hard line breaks
+=== Enabling hard line breaks
 
-The Jekyll AsciiDoc integration is configured to preserve hard line breaks in paragraph content by default.
-Since many Jekyll users are used to writing in GitHub-flavored Markdown (GFM), this default was selected to ease the transition to AsciiDoc.
-If you want the standard AsciiDoc behavior of collapsing hard line breaks in paragraph content, add the following settings to your site's [path]_{empty}_config.yml_ file:
+Many Jekyll users are used to writing in GitHub-flavored Markdown (GFM), which preserves hard line breaks in paragraph content.
+Asciidoctor supports this feature for AsciiDoc files.
+(In fact, previous versions of this plugin enabled this behavior by default).
+If you want to enable this behavior for AsciiDoc files, add the `hardbreaks-option` attribute to the Asciidoctor attributes configuration in your site's [path]_{empty}_config.yml_ file:
 
 [source,yaml]
 ----
 asciidoctor:
   attributes:
-    - hardbreaks!
+    - hardbreaks-option
 ----
 
-If you already have AsciiDoc attributes defined in the [path]_{empty}_config.yml_, the `hardbreaks!` attribute should be added as a sibling entry in the YAML collection.
+If you want to allow individual files to override this setting, then assign the value `@` to the attribute:
+
+[source,yaml]
+----
+asciidoctor:
+  attributes:
+    - hardbreaks-option=@
+----
+
+If you already have AsciiDoc attributes defined in the [path]_{empty}_config.yml_, the new attribute should be added as a sibling entry in the YAML collection.
+
+WARNING: Keep in mind, if you enable hard line breaks, you won't be able to use the http://asciidoctor.org/docs/asciidoc-recommended-practices/#one-sentence-per-line[one sentence-per-line writing technique].
 
 == Enabling Asciidoctor Diagram (optional)
 

--- a/lib/jekyll-asciidoc.rb
+++ b/lib/jekyll-asciidoc.rb
@@ -36,7 +36,7 @@ module Jekyll
           end
           asciidoctor_config[:safe] ||= 'safe'
           (asciidoctor_config[:attributes] ||= []).tap do |attributes|
-            attributes.unshift('notitle', 'hardbreaks', 'idprefix', 'idseparator=-', 'linkattrs')
+            attributes.unshift('notitle', 'idprefix', 'idseparator=-', 'linkattrs')
             attributes.concat(IMPLICIT_ATTRIBUTES)
           end
           if ::Jekyll::MIN_VERSION_3 && !config['asciidoc_require_front_matter']


### PR DESCRIPTION
- disable hard line breaks by default (i.e., `hardbreaks` attribute)
- document how to reeanble