### PR TITLE
redefine has_yaml_header? method properly

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,14 +94,14 @@ gems:
 
 == Creating Pages
 
-This plugin converts eligible AsciiDoc files found inside the source directory (typically the project root) to pages in the generated site.
-There are a few conditions that must be met for an AsciiDoc file to be qualified:
+This plugin converts eligible AsciiDoc files located inside the source directory (by default, the project root) to HTML pages in the generated site.
+There are a few conditions that must be met in order for an AsciiDoc file to be eligible:
 
 . The file must have an AsciiDoc file extension (see <<configuration>>).
-. The name of the file must not begin with a dot (`.`) or underscore (`_`).footnoteref:[excluded_files,These files are excluded by Jekyll.]
-. The file must not be located in a folder whose name begins with a dot (`.`) or underscore (`_`), except for posts.footnoteref:[excluded_files]
-. With the exception of posts, documents must begin with a {uri-front-matter}[front matter header] if you're using a version of this plugin < 2.0.0 or a version of Jekyll < 2.3.0.
-Since version 2.0.0 of this plugin, if you're using Jekyll >= 2.3.0, the front matter header is always optional.
+. The name of the file must not begin with a dot (`.`) or an underscore (`_`).footnoteref:[excluded_files,These files are excluded by Jekyll.]
+. The file must not be located in a folder whose name begins with a dot (`.`) or an underscore (`_`), unless the folder is a designated collection (e.g., posts).footnoteref:[excluded_files]
+. With the exception of posts, documents must begin with a {uri-front-matter}[front matter header] if the version of this plugin is < 2.0.0 or the version of Jekyll is < 2.3.0.
+Since version 2.0.0 of this plugin, the front matter header is always optional if you're using Jekyll >= 2.3.0.
 
 Here's a sample AsciiDoc file that meets these criteria:
 
@@ -245,8 +245,8 @@ asciidoc:
 
 A hyphen is automatically added to the value of this configuration setting if the value is non-empty.
 
-By default, all eligible AsciiDoc files are processed (since version 2.0.0 of this plugin used with Jekyll >= 2.3.0).
-If you only want files containing a front matter header to be processed (as was the behavior before version 2.0.0), add the `require_front_matter_header` option to the `asciidoc` block of your {path-config}:
+Since version 2.0.0 of this plugin, when used with Jekyll >= 2.3.0, all non-hidden AsciiDoc files are processed by default, even those without a front matter header.
+If you only want files containing a front matter header to be processed (as was the behavior prior to version 2.0.0), add the `require_front_matter_header` option to the `asciidoc` block of your {path-config}:
 
 [source,yaml]
 ----

--- a/README.adoc
+++ b/README.adoc
@@ -100,8 +100,8 @@ There are a few conditions that must be met for an AsciiDoc file to be qualified
 . The file must have an AsciiDoc file extension (see <<configuration>>).
 . The name of the file must not begin with a dot (`.`) or underscore (`_`).footnoteref:[excluded_files,These files are excluded by Jekyll.]
 . The file must not be located in a folder whose name begins with a dot (`.`) or underscore (`_`), except for posts.footnoteref:[excluded_files]
-. The document must begin with a {uri-front-matter}[front matter header] prior to version 1.2.0 of this plugin (except for posts).
-Since version 1.2.0, the front matter header is always optional.
+. With the exception of posts, documents must begin with a {uri-front-matter}[front matter header] if you're using a version of this plugin < 1.2.0 or a version of Jekyll < 2.3.0.
+Since version 1.2.0 of this plugin, if you're using Jekyll >= 2.3.0, the front matter header is always optional.
 
 Here's a sample AsciiDoc file that meets these criteria:
 
@@ -175,7 +175,7 @@ IMPORTANT: AsciiDoc files may include a {uri-front-matter}[front matter header] 
 If present, the front matter header must be the very first character of the file.
 The front matter header won't be seen--and could disrupt conversion--if the front matter is preceded by a whitespace character or a Byte Order Mark (BOM).
 
-NOTE: As of version 1.2.0 of this plugin, you may exclude the front matter header, as shown in the second example above.
+NOTE: As of version 1.2.0 of this plugin, you may exclude the front matter header if you're using Jekyll >= 2.3.0, as shown in the second example above.
 Prior to version 1.2.0, you had to include at least an empty front matter header (except for posts).
 In these cases, you define all the page metadata (e.g., layout) using AsciiDoc attributes instead of in the front matter.
 You can also use a combination of both.
@@ -245,7 +245,7 @@ asciidoc:
 
 A hyphen is automatically added to the value of this configuration setting if the value is non-empty.
 
-By default, all eligible AsciiDoc files are processed (since version 1.2.0 of this plugin).
+By default, all eligible AsciiDoc files are processed (since version 1.2.0 of this plugin used with Jekyll >= 2.3.0).
 If you only want files containing a front matter header to be processed (as was the behavior before version 1.2.0), add the `require_front_matter_header` option to the `asciidoc` block of your {path-config}:
 
 [source,yaml]

--- a/README.adoc
+++ b/README.adoc
@@ -100,8 +100,8 @@ There are a few conditions that must be met for an AsciiDoc file to be qualified
 . The file must have an AsciiDoc file extension (see <<configuration>>).
 . The name of the file must not begin with a dot (`.`) or underscore (`_`).footnoteref:[excluded_files,These files are excluded by Jekyll.]
 . The file must not be located in a folder whose name begins with a dot (`.`) or underscore (`_`), except for posts.footnoteref:[excluded_files]
-. With the exception of posts, documents must begin with a {uri-front-matter}[front matter header] if you're using a version of this plugin < 1.2.0 or a version of Jekyll < 2.3.0.
-Since version 1.2.0 of this plugin, if you're using Jekyll >= 2.3.0, the front matter header is always optional.
+. With the exception of posts, documents must begin with a {uri-front-matter}[front matter header] if you're using a version of this plugin < 2.0.0 or a version of Jekyll < 2.3.0.
+Since version 2.0.0 of this plugin, if you're using Jekyll >= 2.3.0, the front matter header is always optional.
 
 Here's a sample AsciiDoc file that meets these criteria:
 
@@ -164,7 +164,7 @@ In addition to page attributes defined explicitly, the following implicit AsciiD
 * author
 * revdate (becomes date; value is converted to a DateTime object; only for posts)
 
-Unlike other content files, the {uri-liquid-templates}[Liquid template preprocessor] is not applied to AsciiDoc files by default (as of version 1.2.0 of this plugin).
+Unlike other content files, the {uri-liquid-templates}[Liquid template preprocessor] is not applied to AsciiDoc files by default (as of version 2.0.0 of this plugin).
 If you want the Liquid template preprocessor to be applied to an AsciiDoc file (prior to the content being passed to the AsciiDoc processor), you must enable it by setting the liquid page variable.
 
 ----
@@ -175,8 +175,8 @@ IMPORTANT: AsciiDoc files may include a {uri-front-matter}[front matter header] 
 If present, the front matter header must be the very first character of the file.
 The front matter header won't be seen--and could disrupt conversion--if the front matter is preceded by a whitespace character or a Byte Order Mark (BOM).
 
-NOTE: As of version 1.2.0 of this plugin, you may exclude the front matter header if you're using Jekyll >= 2.3.0, as shown in the second example above.
-Prior to version 1.2.0, you had to include at least an empty front matter header (except for posts).
+NOTE: As of version 2.0.0 of this plugin, you may exclude the front matter header if you're using Jekyll >= 2.3.0, as shown in the second example above.
+Prior to version 2.0.0, you had to include at least an empty front matter header (except for posts).
 In these cases, you define all the page metadata (e.g., layout) using AsciiDoc attributes instead of in the front matter.
 You can also use a combination of both.
 When intermixed, the attributes defined in the AsciiDoc header take precedence.
@@ -208,7 +208,7 @@ This section describes the configuration options for this plugin, which are all 
 
 === AsciiDoc
 
-NOTE: Prior to version 1.2.0 of this plugin, the configuration keys in this section were defined as flat, top-level names (e.g., `asciidoc_ext`).
+NOTE: Prior to version 2.0.0 of this plugin, the configuration keys in this section were defined as flat, top-level names (e.g., `asciidoc_ext`).
 These names are now deprecated, but still supported.
 
 By default, this plugin uses Asciidoctor to convert AsciiDoc files.
@@ -245,8 +245,8 @@ asciidoc:
 
 A hyphen is automatically added to the value of this configuration setting if the value is non-empty.
 
-By default, all eligible AsciiDoc files are processed (since version 1.2.0 of this plugin used with Jekyll >= 2.3.0).
-If you only want files containing a front matter header to be processed (as was the behavior before version 1.2.0), add the `require_front_matter_header` option to the `asciidoc` block of your {path-config}:
+By default, all eligible AsciiDoc files are processed (since version 2.0.0 of this plugin used with Jekyll >= 2.3.0).
+If you only want files containing a front matter header to be processed (as was the behavior before version 2.0.0), add the `require_front_matter_header` option to the `asciidoc` block of your {path-config}:
 
 [source,yaml]
 ----

--- a/lib/jekyll-asciidoc/version.rb
+++ b/lib/jekyll-asciidoc/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module AsciiDoc
-    VERSION = '1.2.0.dev'
+    VERSION = '2.0.0.dev'
   end
 end

--- a/spec/fixtures/require_front_matter_header/_config.yml
+++ b/spec/fixtures/require_front_matter_header/_config.yml
@@ -1,0 +1,4 @@
+gems:
+  - jekyll-asciidoc
+asciidoc:
+  require_front_matter_header: true

--- a/spec/fixtures/require_front_matter_header/_layouts/default.html
+++ b/spec/fixtures/require_front_matter_header/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<div class="page-content">
+{{ content }}
+</div>
+</body>
+</html>

--- a/spec/fixtures/require_front_matter_header/with-front-matter-header.adoc
+++ b/spec/fixtures/require_front_matter_header/with-front-matter-header.adoc
@@ -1,0 +1,5 @@
+---
+---
+= Page Title
+
+Lorem ipsum.

--- a/spec/fixtures/require_front_matter_header/without-front-matter-header.adoc
+++ b/spec/fixtures/require_front_matter_header/without-front-matter-header.adoc
@@ -1,0 +1,3 @@
+= Page Title
+
+Lorem ipsum.

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -313,6 +313,39 @@ describe(Jekyll::AsciiDoc) do
     end
   end
 
+  describe('require front matter header') do
+    let(:name) do
+      'require_front_matter_header'
+    end
+
+    before(:each) do
+      site.process
+    end
+
+    it 'should consider an AsciiDoc file with a front matter header to have a YAML header' do
+      file = source_file('with-front-matter-header.adoc')
+      expect(Jekyll::Utils.has_yaml_header?(file)).to be true
+    end
+
+    it 'should consider an AsciiDoc file without a front matter header to not have a YAML header' do
+      file = source_file('without-front-matter-header.adoc')
+      expect(Jekyll::Utils.has_yaml_header?(file)).to be false
+    end
+
+    it 'should convert an AsciiDoc file with a front matter header' do
+      file = output_file('with-front-matter-header.html')
+      expect(File).to exist(file)
+      contents = File.read(file)
+      expect(contents).to match('<title>Page Title</title>')
+      expect(contents).to match('<p>Lorem ipsum.</p>')
+    end
+
+    it 'should not convert an AsciiDoc file without a front matter header' do
+      file = output_file('without-front-matter-header.adoc')
+      expect(File).to exist(file)
+    end
+  end
+
   describe('site with posts') do
     let(:name) do
       'with_posts'


### PR DESCRIPTION
- store reference to original method
- restore original method if require_front_matter_header is true
- always delegate to original method (not previously curried method)
- add tests to ensure require_front_matter_header config option is enforced