### PR TITLE
resolves #37 add liquid filter to generate toc

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,29 +5,35 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {uri-repo}/commits/master[commit history] on GitHub.
 
+== Unreleased
+
+* Add `tocify_asciidoc` Liquid filter for generating a table of contents from the parsed AsciiDoc document (Jekyll 3+ only)
+* Set minimum version of Ruby to 1.9.3 in the gemspec
+
 == 2.0.1 (2016-07-06) - @mojavelinux
 
-* align localtime and localdate attributes with site.time and site.timezone (#117)
-* don't register hook callbacks again when regenerating site; use static methods for hook callbacks (#121)
-* bundle CHANGELOG.adoc and test suite in gem
-* minor improvements to README
+* Align localtime and localdate attributes with site.time and site.timezone (#117)
+* Don't register hook callbacks again when regenerating site; use static methods for hook callbacks (#121)
+* Bundle CHANGELOG.adoc and test suite in gem
+* Minor improvements to README
 
 == 2.0.0 (2016-07-02) - @mojavelinux
 
 * Split source into multiple files; move all classes under the `Jekyll::AsciiDoc` module
 * Avoid redundant initialization caused by the jekyll-watch plugin
-* Set docdir, docfile, docname, outfile, outdir, and outpath attributes for each file if using Jekyll 3 (#59)
+* Set docdir, docfile, docname, outfile, outdir, and outpath attributes for each file (Jekyll 3+ only) (#59)
   - docdir is only set if value of `base_dir` option is `:docdir`
   - setting outdir allows proper integration with Asciidoctor Diagram
 * Automatically set `imagesoutdir` attribute if `imagesdir` attribute is relative to root
 * Pass site information (root, source, destination, baseurl and url) through as AsciiDoc attributes
 * Automatically generate stylesheet for Pygments (#30)
 * Change default layout to match collection label (#104)
-  - page for pages, post for posts, collection label for all others; use default layout as fallback
+  - page for pages, post for posts, collection label for all others
+  - use layout named default as fallback
 * Resolve attribute references in attribute values defined in config (#103)
 * Apply AsciiDoc header integration to documents in all collections (#93)
 * Document how to create and enable templates to customize the HTML that Asciidoctor generates (#73)
-* Allow `base_dir` option to track document directory by setting the value to `:docdir` (#80)
+* Allow `base_dir` option to track document directory by setting the value to `:docdir` (Jekyll 3 only) (#80)
 * Add a comprehensive test suite (#77)
 * Allow site-wide Asciidoctor attributes to be specified as a Hash; convert to Hash if Array is used (#87)
 * Interpret page attribute values as YAML data
@@ -45,7 +51,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Allow plugin to work in safe mode (#112)
 * Major restructure and rewrite of README
 * Document how to use plugin with GitLab Pages (#47)
-* Document asciidocify filter
+* Document `asciidocify` Liquid filter
 
 {uri-repo}/issues?q=milestone%3Av2.0.0[issues resolved] |
 {uri-repo}/releases/tag/v2.0.0[git tag]

--- a/README.adoc
+++ b/README.adoc
@@ -65,10 +65,12 @@ Converts AsciiDoc files to HTML pages.
 This plugin currently uses Asciidoctor to convert AsciiDoc content.
 
 Generator -- `Jekyll::AsciiDoc::Integrator`::
-Promotes select AsciiDoc attributes (e.g., title, author, page-layout, page-*) to page variables (merged with the page variables defined in the front matter header).
+Promotes eligible AsciiDoc attributes (e.g., doctitle, author, and attributes that begin with the page attribute prefix) to page variables.
+These attributes are merged with the page variables defined in the front matter header.
 
-Liquid Filter -- `asciidocify`::
-A Liquid filter that uses the converter from this plugin to convert AsciiDoc content to HTML.
+Liquid Filters::
+* `asciidocify` -- Uses the converter from this plugin to convert a string of AsciiDoc content to HTML.
+* `tocify_asciidoc` -- Generates a table of contents in HTML from the parsed AsciiDoc document of the current page (Jekyll 3+ and Asciidoctor only).
 
 These extensions are registered automatically when the [app]*jekyll-asciidoc* gem is required.
 
@@ -779,10 +781,14 @@ asciidoctor:
 
 Then, simply put the icon images that the page needs in the [path]_images/icons_ directory.
 
-== Converting AsciiDoc in Templates
+== Working with AsciiDoc Content in Templates
 
 Jekyll uses the Liquid templating language to process templates.
-This plugin defines an additional filter named `asciidocify` for converting a string of AsciiDoc.
+This plugin defines two additional Liquid filters, `asciidocify` and `tocify_asciidoc`, for working with AsciiDoc content in those templates.
+
+=== Converting a String from AsciiDoc
+
+You can use the `asciidocify` filter to convert an arbitrary AsciiDoc string anywhere in your template.
 
 Let's assume the excerpt of the post is written in AsciiDoc.
 You can convert it in your template as follows:
@@ -791,13 +797,31 @@ You can convert it in your template as follows:
 {{ post.excerpt | asciidocify }}
 ----
 
-If you only want to perform inline substitutions on the content, add the `inline` doctype as the first argument:
+By default, the AsciiDoc content is parsed as a full AsciiDoc document.
+If the content represents a single paragraph, and you only want to perform inline substitutions on that content, add the `inline` doctype as the filter's first argument:
 
 ----
 {{ post.excerpt | asciidocify: 'inline' }}
 ----
 
-This filter allows you to compose site-wide data in AsciiDoc, such your site's description or synopsis, then convert it to HTML for use in the page template(s).
+TIP: This filter allows you to compose site-wide data in AsciiDoc, such your site's description or synopsis, then convert it to HTML for use in the page template(s).
+
+=== Generating a Table of Contents
+
+If you're using Jekyll 3 or better, you can use the `tocify_asciidoc` filter to generate a table of contents in HTML for any page created from an AsciiDoc document.
+
+This filter gets applied to `page.document`, the page variable that resolves to the parsed AsciiDoc document, as shown here:
+
+----
+{{ page.document | tocify_asciidoc }}
+----
+
+The number of section levels (i.e., depth) shown in the table of contents defaults to the value defined by the `toclevels` attribute in the AsciiDoc document.
+To tune the number of levels, pass a numeric value as the filter's first argument.
+
+----
+{{ page.document | tocify_asciidoc: 3 }}
+----
 
 == Using this Plugin on GitHub Pages
 

--- a/lib/jekyll-asciidoc/filters.rb
+++ b/lib/jekyll-asciidoc/filters.rb
@@ -6,10 +6,30 @@ module Jekyll
       # input   - The AsciiDoc String to convert.
       # doctype - The target AsciiDoc doctype (optional, default: nil).
       #
-      # Returns the HTML formatted String.
+      # Examples
+      #
+      #   {{ page.excerpt | asciidocify: 'inline' }}
+      #
+      # Returns the converted result as an HTML-formatted String.
       def asciidocify input, doctype = nil
         (@context.registers[:cached_asciidoc_converter] ||= (Converter.get_instance @context.registers[:site]))
           .convert(doctype ? %(:doctype: #{doctype}#{Utils::NewLine}#{input}) : (input || ''))
+      end
+
+      # A Liquid filter for generating a table of contents in HTML from a parsed AsciiDoc document.
+      #
+      # document      - The parsed AsciiDoc document from which to generate a table of contents in HTML.
+      # levels        - The max section depth to include (optional, default: value of toclevels document attribute).
+      #
+      # Examples
+      #
+      #   {{ page.document | tocify_asciidoc: 3 }}
+      #
+      # Returns the table of contents as an HTML-formatted String.
+      def tocify_asciidoc document, levels = nil
+        if ::Asciidoctor::Document === document
+          document.converter.convert document, 'outline', toclevels: (levels.nil_or_empty? ? nil : levels.to_i)
+        end
       end
     end
 

--- a/lib/jekyll-asciidoc/mixins.rb
+++ b/lib/jekyll-asciidoc/mixins.rb
@@ -3,6 +3,12 @@ module Jekyll
     Configured = ::Module.new
     Document = ::Module.new
 
+    module Liquidable
+      def to_liquid
+        self
+      end
+    end
+
     module NoLiquid
       def render_with_liquid?
         false

--- a/spec/fixtures/tocify_filter/_config.yml
+++ b/spec/fixtures/tocify_filter/_config.yml
@@ -1,0 +1,2 @@
+gems:
+  - jekyll-asciidoc

--- a/spec/fixtures/tocify_filter/_layouts/default.html
+++ b/spec/fixtures/tocify_filter/_layouts/default.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<div class="page-content">
+{{ content }}
+</div>
+<aside class="page-toc">
+{{ page.document | tocify_asciidoc: 2 }}
+</aside>
+</body>
+</html>

--- a/spec/fixtures/tocify_filter/index.adoc
+++ b/spec/fixtures/tocify_filter/index.adoc
@@ -1,0 +1,25 @@
+= Page Title
+
+== Major Section A
+
+content
+
+=== Minor Section A.1
+
+content
+
+== Major Section B
+
+content
+
+=== Minor Section B.1
+
+content
+
+==== Micro Section B.1.1
+
+content
+
+== Major Section C
+
+content

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -877,4 +877,24 @@ describe 'Jekyll::AsciiDoc' do
       expect(contents).to match('<img src="/images/sunset.jpg" alt="Sunset" width="408" height="230"/>')
     end
   end
+
+  describe 'tocify filter' do
+    let :name do
+      'tocify_filter'
+    end
+
+    before :each do
+      site.process
+    end
+
+    it 'should generate document outline when tocify_asciidoc filter is applied to page.document' do
+      file = output_file 'index.html'
+      expect(::File).to exist(file)
+      contents = ::File.read file
+      aside = contents.match(/<aside class="page-toc">.*<\/aside>/m)[0]
+      expect(aside).to match('<ul class="sectlevel1">')
+      expect(aside).to match('<a href="#major-section-a">Major Section A</a>')
+      expect(aside).not_to match('Micro Section')
+    end
+  end if ::Jekyll::MIN_VERSION_3
 end


### PR DESCRIPTION
- promote current document to page variable named document
- add to_liquid method to ::Asciidoctor::Document
- add tocify_asciidoc filter to generate toc from ::Asciidoctor::Document instance
- add test for tocify_asciidoc filter
- document tocify_asciidoc filter in README

NOTE: This Liquid filter is only available when using Jekyll 3 or better.