### PR TITLE
resolves #117 align localtime and localdate attributes with site.time

### DIFF
--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -14,6 +14,8 @@ module Jekyll
         site.find_generator_instance self
       end
 
+      # This method is triggered each time the site is generated, including after any file has changed when
+      # running in watch mode (regardless of incremental setting).
       def generate site
         @converter = converter = (Converter.get_instance site).setup
 
@@ -37,8 +39,9 @@ module Jekyll
           end
         end
 
-        if (attrs = site.config['asciidoctor'][:attributes]) &&
-            ((attrs['source-highlighter'] || '').chomp '@') == 'pygments' &&
+        attrs = site.config['asciidoctor'][:attributes]
+        attrs['localdate'], attrs['localtime'] = (site.time.strftime '%Y-%m-%d %H:%M:%S %Z').split ' ', 2
+        if ((attrs['source-highlighter'] || '').chomp '@') == 'pygments' &&
             ((attrs['pygments-css'] || '').chomp '@') != 'style' && (attrs.fetch 'pygments-stylesheet', '')
           generate_pygments_stylesheet site, attrs
         end

--- a/spec/fixtures/explicit_site_time/_config.yml
+++ b/spec/fixtures/explicit_site_time/_config.yml
@@ -1,0 +1,4 @@
+time: 2016-07-04T09:15:00
+timezone: UTC
+gems:
+  - jekyll-asciidoc

--- a/spec/fixtures/explicit_site_time/_layouts/default.html
+++ b/spec/fixtures/explicit_site_time/_layouts/default.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<div class="page-content">
+{{ content }}
+</div>
+</body>
+</html>

--- a/spec/fixtures/explicit_site_time/home.adoc
+++ b/spec/fixtures/explicit_site_time/home.adoc
@@ -1,0 +1,3 @@
+= Home Page
+
+* localdatetime={localdatetime}

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -469,6 +469,27 @@ describe Jekyll::AsciiDoc do
     end if ::Jekyll::MIN_VERSION_3
   end
 
+  describe 'explicit site time' do
+    let :name do
+      'explicit_site_time'
+    end
+
+    before :each do
+      site.process
+    end
+
+    it 'should set localdatetime on AsciiDoc pages to match site time and timezone' do
+      expect(asciidoctor_config = site.config['asciidoctor']).to be_a(::Hash)
+      expect(attrs = asciidoctor_config[:attributes]).to be_a(::Hash)
+      expect(attrs['localdate']).to eql(site.time.strftime '%Y-%m-%d')
+      expect(attrs['localtime']).to eql(site.time.strftime '%H:%M:%S %Z')
+      file = output_file 'home.html'
+      expect(::File).to exist(file)
+      contents = ::File.read file
+      expect(contents).to match(%(localdatetime=#{site.time.strftime '%Y-%m-%d %H:%M:%S %Z'}))
+    end
+  end
+
   describe 'safe mode' do
     let :name do
       'safe_mode'


### PR DESCRIPTION
- align localtime and localdate AsciiDoc attributes with site.time and site.timezone
- add test to verify localdatetime matches site.time
- document conditions under which generate method is invoked