### PR TITLE
only register hooks once

### DIFF
--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -137,12 +137,20 @@ module Jekyll
         '.html'
       end
 
+      def self.before_render document, payload
+        (Utils.get_converter document.site).before_render document, payload if Document === document
+      end
+
+      def self.after_render document
+        (Utils.get_converter document.site).after_render document if Document === document
+      end
+
       def before_render document, payload
-        record_path_info document if Document === document
+        record_path_info document
       end
 
       def after_render document
-        clear_path_info if Document === document
+        clear_path_info
       end
 
       def record_path_info document, opts = {}

--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -15,11 +15,11 @@ module Jekyll
         @converter = converter = (Utils.get_converter site).setup
 
         if defined? ::Jekyll::Hooks
-          before_render_callback = converter.method :before_render
-          after_render_callback = converter.method :after_render
-          [:pages, :documents].each do |collection_name|
-            ::Jekyll::Hooks.register collection_name, :pre_render, &before_render_callback
-            ::Jekyll::Hooks.register collection_name, :post_render, &after_render_callback
+          # NOTE the hooks registry is global, so guard against registering hooks again on regenerate
+          unless Configured === (registry = (hooks = ::Jekyll::Hooks).instance_variable_get :@registry)
+            hooks.register [:pages, :documents], :pre_render, &(Converter.method :before_render)
+            hooks.register [:pages, :documents], :post_render, &(Converter.method :after_render)
+            registry.extend Configured
           end
         end
 

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -445,6 +445,25 @@ describe Jekyll::AsciiDoc do
         expect(contents).to match(%(docname=#{::File.basename src_file, '.adoc'}))
       end
     end
+
+    it 'should only register pre and post render hooks once' do
+      hooks_registry = ::Jekyll::Hooks.instance_variable_get :@registry
+      after_site_reset = hooks_registry[:site][:after_reset].pop
+      begin
+        expect(hooks_registry[:pages][:pre_render].size).to eql(1)
+        expect(hooks_registry[:pages][:post_render].size).to eql(1)
+        expect(hooks_registry[:documents][:pre_render].size).to eql(1)
+        expect(hooks_registry[:documents][:post_render].size).to eql(1)
+        site.process
+        expect(hooks_registry).to be_a(::Jekyll::AsciiDoc::Configured)
+        expect(hooks_registry[:pages][:pre_render].size).to eql(1)
+        expect(hooks_registry[:pages][:post_render].size).to eql(1)
+        expect(hooks_registry[:documents][:pre_render].size).to eql(1)
+        expect(hooks_registry[:documents][:post_render].size).to eql(1)
+      ensure
+        hooks_registry[:site][:after_reset] << after_site_reset
+      end
+    end if ::Jekyll::MIN_VERSION_3
   end
 
   describe 'safe mode' do


### PR DESCRIPTION
- only register callbacks for pre_render and post_render hooks once
- register callbacks as static methods so they work on any site instance
- add test to ensure hook callbacks are only registered once