### PR TITLE
parse revdate using Jekyll::Utils.parse_date

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,7 +15,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Enable CI for Windows platform by configuring job on AppVeyor
 * Catch SyntaxError when using Psych YAML parser with Ruby 1.9.3
 * Document that the name of page variable created from a page attribute is automatically lowercased
-* Minor improvements to README
+* Parse the value of the revdate attribute using `Jekyll::Utils.parse_date`
+* Document how to assign a specific time to a post
+* Add additional documentation and make other minor improvements to the README
 
 == 2.0.1 (2016-07-06) - @mojavelinux
 

--- a/README.adoc
+++ b/README.adoc
@@ -216,6 +216,38 @@ In addition to page attributes defined explicitly, the following implicit AsciiD
 * author
 * revdate (becomes date; value is converted to a DateTime object; posts only)
 
+==== Giving Your Post the Time of Day
+
+By default, all posts are assigned a date that is computed from the file name (e.g., the date for 2016-03-20-welcome.adoc is 2016-03-20).
+If you want to give your post a specific time as well, you can set the `revdate` attribute in the AsciiDoc header.
+
+We recommend using the format `YYYY-MM-DD HH:MM:SS Z` as shown in this example:
+
+[source,asciidoc]
+----
+= Post Title
+Author Name
+:revdate: 2016-03-20 10:30:00 -0600
+
+Lorem ipsum.
+----
+
+If you don't provide a time zone in the date, the date is assumed to be in the same time zone as the site (which is your local time zone by default).
+
+Alternatively, you can specify the date in the implicit revision line.
+In this case, you must substitute the colons in the time part with "h", "m", and "s", respectively, since the colon demarcates the revision remark.
+
+[source,asciidoc]
+----
+= Post Title
+Author Name
+2016-03-20 10h30m00s -0600
+
+Lorem ipsum.
+----
+
+Note that the revision line must be preceded by the implicit author line.
+
 === Enabling Liquid Preprocessing
 
 Unlike other content files, the {uri-liquid-templates}[Liquid template preprocessor] is not applied to AsciiDoc files by default (as of version 2.0.0 of this plugin).

--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -61,7 +61,12 @@ module Jekyll
 
         document.data['title'] = doc.doctitle if doc.header?
         document.data['author'] = doc.author if doc.author
-        document.data['date'] = (::DateTime.parse doc.revdate).to_time if collection_name == 'posts' && (doc.attr? 'revdate')
+        if collection_name == 'posts' && (doc.attr? 'revdate')
+          document.data['date'] = ::Jekyll::Utils.parse_date doc.revdate,
+              %(Document '#{document.relative_path}' does not have a valid revdate in the AsciiDoc header.)
+          # NOTE Jekyll 2.3 requires date field to be set explicitly
+          document.date = document.data['date'] if document.respond_to? :date=
+        end
 
         no_prefix = (prefix_size = @page_attr_prefix.length).zero?
         unless (adoc_header_data = doc.attributes

--- a/spec/fixtures/with_posts/_layouts/post.html
+++ b/spec/fixtures/with_posts/_layouts/post.html
@@ -5,9 +5,17 @@
 <title>{{ page.title }}</title>
 </head>
 <body>
+<article class="post">
+<header class="post-header">
+<h1 class="post-title">{{ page.title }}</h1>
+<p class="post-details">
+<time class="date-published" datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%B %d, %Y" }}</time>
+</p>
+</header>
 <div class="post-content">
 {{ content }}
 </div>
+</article>
 <footer>
 <p>Footer for post layout.</p>
 </footer>

--- a/spec/fixtures/with_posts/_posts/2016-06-15-post-with-date.adoc
+++ b/spec/fixtures/with_posts/_posts/2016-06-15-post-with-date.adoc
@@ -1,0 +1,4 @@
+= Post With Date
+:revdate: 2016-06-15 10:30:00
+
+Lorem ipsum.

--- a/spec/fixtures/with_posts/_posts/2016-07-15-post-with-date-and-tz.adoc
+++ b/spec/fixtures/with_posts/_posts/2016-07-15-post-with-date-and-tz.adoc
@@ -1,0 +1,4 @@
+= Post With Date and Time Zone
+:revdate: 2016-07-15 04:15:30 -0600
+
+Lorem ipsum.

--- a/spec/fixtures/with_posts/_posts/2016-07-20-post-with-date-in-revision-line.adoc
+++ b/spec/fixtures/with_posts/_posts/2016-07-20-post-with-date-in-revision-line.adoc
@@ -1,0 +1,6 @@
+= Post With Date in Revision Line
+Author Name
+// NOTE cannot use colon in date because it's used as the delimiter for the revision remark
+2016-07-20 05h45m25s -0600
+
+Lorem ipsum.


### PR DESCRIPTION
- parse value of revdate attribute in posts using Jekyll::Utils.parse_date
- add tests to verify revdate is parsed correctly and assigned as date of post
- document how to specify time part for post date