### PR TITLE
clear residual :docdir value of base_dir option before conversion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -17,6 +17,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * Document that the name of page variable created from a page attribute is automatically lowercased
 * Parse the value of the revdate attribute using `Jekyll::Utils.parse_date`
 * Document how to assign a specific time to a post
+* Fix crash when converting an auto-extracted excerpt when base_dir option is set to :docdir
 * Add additional documentation and make other minor improvements to the README
 
 == 2.0.1 (2016-07-06) - @mojavelinux

--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -218,6 +218,9 @@ module Jekyll
               paths.delete 'docdir'
             end
             opts[:attributes] = opts[:attributes].merge paths
+          # for auto-extracted excerpt, paths are't available since hooks don't get triggered
+          elsif opts[:base_dir] == :docdir
+            opts.delete :base_dir
           end
           ((@page_context[:data] || {})['document'] = ::Asciidoctor.load content, opts).extend(Liquidable).convert
         else

--- a/spec/fixtures/with_posts/_config.yml
+++ b/spec/fixtures/with_posts/_config.yml
@@ -1,2 +1,6 @@
 gems:
   - jekyll-asciidoc
+asciidoctor:
+  # base_dir is set to :docdir here to verify excerpt conversion doesn't break
+  # we probably want to create a dedicated fixture for this scenario
+  base_dir: :docdir


### PR DESCRIPTION
- auto-extracted excerpt is parsed by converter, but hooks aren't triggered
- clear :docdir value of base_dir if paths not available