### PR TITLE
fix tocify filter

### DIFF
--- a/lib/jekyll-asciidoc/compat.rb
+++ b/lib/jekyll-asciidoc/compat.rb
@@ -1,6 +1,7 @@
 module Jekyll
   module AsciiDoc
-    Jekyll3Compatible = (::Gem::Version.new ::Jekyll::VERSION) >= (::Gem::Version.new '3.0.0')
+    Jekyll3Compatible = (jekyll_version = ::Gem::Version.new ::Jekyll::VERSION) >= (::Gem::Version.new '3.0.0')
+    Jekyll3_1 = (::Gem::Requirement.new '~> 3.1.0').satisfied_by? jekyll_version
   end
 end
 

--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -151,7 +151,8 @@ module Jekyll
       end
 
       def before_render document, payload
-        @page_context[:data] = document.data
+        # NOTE Jekyll 3.1 incorrectly mapped the page payload to document.data instead of payload['page']
+        @page_context[:data] = ::Jekyll::AsciiDoc::Jekyll3_1 ? document.data : payload['page']
         record_paths document
       end
 


### PR DESCRIPTION
- use correct page payload for the version of Jekyll in use