### PR TITLE
Don't delete category and tag properties when merging them into categories and tags, respectively

### DIFF
--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -80,7 +80,7 @@ module Jekyll
         end
 
         { 'category' => 'categories', 'tag' => 'tags' }.each do |sole_key, coll_key|
-          if (sole_val = data.delete sole_key) &&
+          if (sole_val = data[sole_key]) &&
               !((coll_val = (data[coll_key] ||= [])).include? sole_val)
             coll_val << sole_val 
           end


### PR DESCRIPTION
In one of my projects, we found that if a page parsed by jekyll-asciidoc inside a collection has a category added to it, that category will not be picked up by liquid filters such as `group_by`. For example, given the following front-matter:

_test_collection/index.adoc
```
---
category: test
---
```

and the following Liquid code:

```
{% assign objects = site.test_collection | group_by: "category" %}
```

`objects` will have a nil value. This pull request fixes that by not deleting the `category` and `tag` properties when merging them into `categories` and `tags`, respectively.