### PR TITLE
resolves #179 handle case when document body is empty

### DIFF
--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -181,7 +181,7 @@ module Jekyll
         setup
         record_paths document, source_only: true if defined? ::Jekyll::Hooks
         # NOTE merely an optimization; if this doesn't match, the header still gets isolated by the processor
-        header = (document.content.split HeaderBoundaryRx, 2)[0]
+        header = (document.content.split HeaderBoundaryRx, 2)[0] || ''
         case @asciidoc_config['processor']
         when 'asciidoctor'
           opts = @asciidoctor_config.merge parse_header_only: true

--- a/spec/fixtures/basic_site/with-front-matter-header-only.adoc
+++ b/spec/fixtures/basic_site/with-front-matter-header-only.adoc
@@ -1,0 +1,4 @@
+---
+title: Front Matter Only
+layout: page
+---

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -446,6 +446,14 @@ describe 'Jekyll::AsciiDoc' do
       expect(contents).to include('<p>Lorem ipsum.</p>')
     end
 
+    it 'should convert an AsciiDoc file with only a front matter header' do
+      file = output_file 'with-front-matter-header-only.html'
+      expect(::File).to exist(file)
+      contents = ::File.read file
+      expect(contents).to include('<title>Front Matter Only</title>')
+      expect(contents).to include(%(<div class="page-content">\n\n</div>))
+    end
+
     it 'should apply explicit id and role attributes on section titles' do
       file = output_file 'section-with-id-and-role.html'
       expect(::File).to exist(file)


### PR DESCRIPTION
- use fallback when document only has a front matter header
- add test