### PR TITLE
resolves #200 automatically extract excerpt for posts and documents written in AsciiDoc

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/master[
 * set date page variable from revdate for any document in a collection (posts or otherwise) (#202)
 * allow non-ASCII word character to be used in name of attribute reference in config file
 * use File.write instead of IO.write (as IO.write has extra magic we don't need)
+* auto-generate excerpts for posts and documents written in AsciiDoc (#200)
 
 == 3.0.0.beta.1 (2018-12-29) - @mojavelinux
 

--- a/README.adoc
+++ b/README.adoc
@@ -421,7 +421,50 @@ If you're using the Liquid include tag to include HTML into the AsciiDoc documen
 ----
 
 This is necessary since AsciiDoc will escape HTML by default.
-To pass it through as is requires enclosing in a passthrough block.
+To pass it through raw requires enclosing it in a passthrough block.
+
+=== Extracting Excerpts
+
+This plugin will extract an excerpt for any post or document in a collection if the `excerpt` page variable isn't set using the same logic as for Markdown files.
+By default, it will use the content between the header and the first blank line.
+If the `excerpt` page variable is set, that value will be used instead.
+The excerpt will automatically be converted from AsciiDoc to embedded HTML whereever the `excerpt` property is referenced in a Liquid template.
+
+----
+{% post.excerpt %}
+----
+
+IMPORTANT: Since version 3.0.0 of this plugin, you no longer have to run the excerpt through the `asciidocify` filter since the conversion is already done for you.
+In fact, if you do, the HTML in the converted excerpt will be escaped, which is not what you want.
+
+If you want to use a different excerpt separator for AsciiDoc files, set the `excerpt_separator` under the `asciidoc` key in the site configuration.
+For example, you can configure the plugin to use the line comment `//more` as the excerpt separator as follows:
+
+[source,yaml]
+----
+asciidoc:
+  excerpt_separator: "\n//more\n"
+----
+
+If you're only working with AsciiDoc files in your site, you can go ahead and set this for all files by using the top-level property:
+
+[source,yaml]
+----
+excerpt_separator: "\n//more\n"
+----
+
+If the excerpt separator isn't found, the content of the whole document is used instead.
+
+By default, the excerpt is converted to HTML using the article doctype.
+If you want to use a different doctype, such as inline, you can set it in the site configuration as follows:
+
+[source,yaml]
+----
+asciidoc:
+  excerpt_doctype: inline
+----
+
+You can also set the excerpt doctype per page using the page attribute named `page-excerpt_doctype`.
 
 == Building and Previewing Your Site
 
@@ -750,22 +793,22 @@ This plugin defines two additional Liquid filters, `asciidocify` and `tocify_asc
 === Converting a String from AsciiDoc
 
 You can use the `asciidocify` filter to convert an arbitrary AsciiDoc string anywhere in your template.
+This filter allows you to compose site-wide data in AsciiDoc, such your site's description or synopsis, then convert it to HTML for use in the page template(s).
 
-Let's assume the excerpt of the post is written in AsciiDoc.
+Let's assume you've defined a page variable named `synopsis` that you want treat as AsciiDoc.
 You can convert it in your template as follows:
 
 ----
-{{ post.excerpt | asciidocify }}
+{{ page.synopsis | asciidocify }}
 ----
 
-By default, the AsciiDoc content is parsed as a full AsciiDoc document.
+By default, the AsciiDoc content is parsed as an embedded AsciiDoc document.
 If the content represents a single paragraph, and you only want to perform inline substitutions on that content, add the `inline` doctype as the filter's first argument:
 
 ----
-{{ post.excerpt | asciidocify: 'inline' }}
+{{ page.synopsis | asciidocify: 'inline' }}
 ----
 
-TIP: This filter allows you to compose site-wide data in AsciiDoc, such your site's description or synopsis, then convert it to HTML for use in the page template(s).
 
 === Generating a Table of Contents
 

--- a/lib/jekyll-asciidoc.rb
+++ b/lib/jekyll-asciidoc.rb
@@ -1,12 +1,15 @@
 module Jekyll
   module AsciiDoc
-    Jekyll3_1 = (::Gem::Requirement.new '~> 3.1.0').satisfied_by? ::Gem::Version.new ::Jekyll::VERSION
+    jekyll_gem_version = ::Gem::Version.new ::Jekyll::VERSION
+    Jekyll3_0 = (::Gem::Requirement.new '~> 3.0.0').satisfied_by? jekyll_gem_version
+    Jekyll3_1 = !Jekyll3_0 && ((::Gem::Requirement.new '~> 3.1.0').satisfied_by? jekyll_gem_version)
   end
 end
 require_relative 'jekyll-asciidoc/core_ext'
 require_relative 'jekyll-asciidoc/jekyll_ext'
 require_relative 'jekyll-asciidoc/utils'
 require_relative 'jekyll-asciidoc/mixins'
+require_relative 'jekyll-asciidoc/excerpt'
 require_relative 'jekyll-asciidoc/converter'
 require_relative 'jekyll-asciidoc/integrator'
 require_relative 'jekyll-asciidoc/filters'

--- a/lib/jekyll-asciidoc/excerpt.rb
+++ b/lib/jekyll-asciidoc/excerpt.rb
@@ -1,0 +1,49 @@
+module Jekyll
+  module AsciiDoc
+    class Excerpt < ::Jekyll::Excerpt
+      if Jekyll3_0
+        def_delegators :@doc, :destination, :url
+      else
+        def_delegators :@doc, :destination
+      end
+
+      def initialize primary_doc, excerpt_content
+        excerpt_doc = primary_doc.dup
+        excerpt_doc.content = excerpt_content
+        excerpt_doc.extend NoLiquid unless primary_doc.data['liquid']
+        super excerpt_doc
+      end
+
+      def extract_excerpt content
+        # NOTE excerpt_doctype has already been resolved from either the page attribute or front matter variable
+        if (doctype = (excerpt_data = data)['excerpt_doctype'] ||
+            (inherited = doc.site.config['asciidoc']['excerpt_doctype']))
+          excerpt_data['doctype'] = doctype
+          excerpt_data['excerpt_doctype'] = doc.data['excerpt_doctype'] = doctype if inherited
+        end
+        content
+      end
+
+      def output
+        unless defined? @output
+          renderer = ::Jekyll::Renderer.new doc.site, self, site.site_payload
+          @output = renderer.run
+          trigger_hooks :post_render
+        end
+        @output
+      end
+
+      def render_with_liquid?
+        !(NoLiquid === doc)
+      end
+
+      # NOTE Jekyll 3.0 incorrectly maps to_liquid to primary doc
+      alias to_liquid data if Jekyll3_0
+
+      def trigger_hooks hook_name, *args
+        #::Jekyll::Hooks.trigger collection.label.to_sym, hook_name, self, *args if collection
+        ::Jekyll::Hooks.trigger :documents, hook_name, self, *args
+      end
+    end
+  end
+end

--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -84,6 +84,12 @@ module Jekyll
           end
         end
 
+        # NOTE excerpt must be set before layout is assigned since excerpt cannot have a layout (or be standalone)
+        unless ::Jekyll::Page === document
+          data['excerpt'] = Excerpt.new document, ((excerpt = data['excerpt']) || doc.source)
+          data['excerpt_origin'] = excerpt ? ((adoc_data.key? 'excerpt') ? 'asciidoc-header' : 'front-matter') : 'body'
+        end
+
         case data['layout']
         when nil
           data['standalone'] = true unless data.key? 'layout'

--- a/spec/fixtures/asciidocify_filter/_config.yml
+++ b/spec/fixtures/asciidocify_filter/_config.yml
@@ -1,0 +1,2 @@
+gems:
+- jekyll-asciidoc

--- a/spec/fixtures/asciidocify_filter/_layouts/default.html
+++ b/spec/fixtures/asciidocify_filter/_layouts/default.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<p class="summary">{{ page.summary | asciidocify: 'inline' }}</p>
+<div class="page-content">
+{{ content }}
+</div>
+</body>
+</html>

--- a/spec/fixtures/asciidocify_filter/index.adoc
+++ b/spec/fixtures/asciidocify_filter/index.adoc
@@ -1,0 +1,6 @@
+---
+summary: A *very* welcoming _welcome_ page.
+---
+= Welcome
+
+Welcome, welcome, welcome!

--- a/spec/fixtures/custom_excerpt_separator/_config.yml
+++ b/spec/fixtures/custom_excerpt_separator/_config.yml
@@ -1,0 +1,5 @@
+gems:
+- jekyll-asciidoc
+excerpt_separator: "<!--more-->"
+asciidoc:
+  excerpt_separator: "\n//more\n"

--- a/spec/fixtures/custom_excerpt_separator/_layouts/post.html
+++ b/spec/fixtures/custom_excerpt_separator/_layouts/post.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<article class="post">
+<header class="post-header">
+<h1 class="post-title">{{ page.title }}</h1>
+</header>
+<div class="post-content">
+{{ content }}
+</div>
+</article>
+<footer>
+<p>Footer for post layout.</p>
+</footer>
+</body>
+</html>

--- a/spec/fixtures/custom_excerpt_separator/_posts/2018-01-01-markdown.md
+++ b/spec/fixtures/custom_excerpt_separator/_posts/2018-01-01-markdown.md
@@ -1,0 +1,11 @@
+---
+title: Excerpt Separator in Markdown
+layout: post
+---
+This is part of the excerpt.
+
+This is also part of the excerpt.
+
+<!--more-->
+
+This is not part of the excerpt.

--- a/spec/fixtures/custom_excerpt_separator/_posts/2018-01-02-asciidoc.adoc
+++ b/spec/fixtures/custom_excerpt_separator/_posts/2018-01-02-asciidoc.adoc
@@ -1,0 +1,9 @@
+= Excerpt Separator in AsciiDoc
+
+This is part of the excerpt.
+
+This is also part of the excerpt.
+
+//more
+
+This is not part of the excerpt.

--- a/spec/fixtures/custom_excerpt_separator/index.html
+++ b/spec/fixtures/custom_excerpt_separator/index.html
@@ -3,16 +3,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Posts</title>
+<title>Post Excerpts</title>
 </head>
 <body>
 <div class="index">
 <h1>Posts</h1>
 <ul class="posts">
 {% for post in site.posts %}
-<li>
-<a href="{{ post.url }}">{{ post.title }}</a>
-{% if post.excerpt != '' %}<div class="excerpt">{{ post.excerpt }}</div>{% endif %}
+<li data-slug="{{ post.slug }}">
+<h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+<p class="excerpt">{{ post.excerpt }}</p>
 </li>
 {% endfor %}
 </ul>

--- a/spec/fixtures/posts_with_excerpts/_config.yml
+++ b/spec/fixtures/posts_with_excerpts/_config.yml
@@ -1,0 +1,2 @@
+gems:
+- jekyll-asciidoc

--- a/spec/fixtures/posts_with_excerpts/_layouts/post.html
+++ b/spec/fixtures/posts_with_excerpts/_layouts/post.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+</head>
+<body>
+<article class="post">
+<header class="post-header">
+<h1 class="post-title">{{ page.title }}</h1>
+</header>
+<div class="post-content">
+{{ content }}
+</div>
+</article>
+<footer>
+<p>Footer for post layout.</p>
+</footer>
+</body>
+</html>

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-01-header-and-single-paragraph.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-01-header-and-single-paragraph.adoc
@@ -1,0 +1,4 @@
+= Header and Single Paragraph
+Author Name
+
+This is the excerpt and body text.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-02-header-and-multiple-paragraphs.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-02-header-and-multiple-paragraphs.adoc
@@ -1,0 +1,6 @@
+= Header and Multiple Paragraphs
+Author Name
+
+This is the excerpt.
+
+This is the rest of the body text that comes after the excerpt.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-03-single-paragraph-only.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-03-single-paragraph-only.adoc
@@ -1,0 +1,4 @@
+---
+title: Paragraph Only
+---
+This is the excerpt and body text.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-04-multiple-paragraphs-only.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-04-multiple-paragraphs-only.adoc
@@ -1,0 +1,6 @@
+---
+title: Multiple Paragraphs Only
+---
+This is the _excerpt_.
+
+This is the rest of the body text that comes after the excerpt.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-05-excerpt-in-header.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-05-excerpt-in-header.adoc
@@ -1,0 +1,6 @@
+= Excerpt in Header
+:page-excerpt: This is the _excerpt_.
+
+This is the first paragraph, but not the excerpt.
+
+This is the rest of the body text.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-06-excerpt-in-front-matter.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-06-excerpt-in-front-matter.adoc
@@ -1,0 +1,8 @@
+---
+excerpt: This is the _excerpt_.
+---
+= Excerpt in Header
+
+This is the first paragraph, but not the excerpt.
+
+This is the rest of the body text.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-07-blank-excerpt.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-07-blank-excerpt.adoc
@@ -1,0 +1,7 @@
+---
+excerpt_separator: ''
+---
+= Blank Excerpt
+Author Name
+
+This document has a blank excerpt because the excerpt_separator is blank.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-08-header-only.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-08-header-only.adoc
@@ -1,0 +1,2 @@
+= AsciiDoc Header Only
+Author Name

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-09-no-liquid.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-09-no-liquid.adoc
@@ -1,0 +1,6 @@
+= No Liquid
+Author Name
+
+{{ page.title }}
+
+This is not part of the excerpt.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-10-with-liquid.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-10-with-liquid.adoc
@@ -1,0 +1,7 @@
+= With Liquid
+Author Name
+:page-liquid:
+
+{{ page.title }}
+
+This is not part of the excerpt.

--- a/spec/fixtures/posts_with_excerpts/_posts/2018-01-11-standalone-layout.adoc
+++ b/spec/fixtures/posts_with_excerpts/_posts/2018-01-11-standalone-layout.adoc
@@ -1,0 +1,7 @@
+= Standalone
+Author Name
+:page-layout: false
+
+Excerpt of post with standalone layout.
+
+This is not part of the excerpt.

--- a/spec/fixtures/posts_with_excerpts/index.html
+++ b/spec/fixtures/posts_with_excerpts/index.html
@@ -3,16 +3,16 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Posts</title>
+<title>Post Excerpts</title>
 </head>
 <body>
 <div class="index">
 <h1>Posts</h1>
 <ul class="posts">
 {% for post in site.posts %}
-<li>
-<a href="{{ post.url }}">{{ post.title }}</a>
-{% if post.excerpt != '' %}<div class="excerpt">{{ post.excerpt }}</div>{% endif %}
+<li data-slug="{{ post.slug }}">
+<h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+<p class="excerpt">{{ post.excerpt }}</p>
 </li>
 {% endfor %}
 </ul>

--- a/spec/fixtures/with_posts/_config.yml
+++ b/spec/fixtures/with_posts/_config.yml
@@ -1,5 +1,7 @@
 gems:
 - jekyll-asciidoc
+asciidoc:
+  excerpt_doctype: inline
 asciidoctor:
   # base_dir is set to :docdir here to verify excerpt conversion doesn't break
   # we probably want to create a dedicated fixture for this scenario

--- a/spec/fixtures/with_posts/_posts/2016-03-02-post-with-excerpt-doctype.adoc
+++ b/spec/fixtures/with_posts/_posts/2016-03-02-post-with-excerpt-doctype.adoc
@@ -1,0 +1,4 @@
+= Post With Excerpt Doctype
+:page-excerpt_doctype: article
+
+Lorem ipsum.


### PR DESCRIPTION
- introduce method to extract header
- include excerpt in source of header for later extraction
- add custom excerpt class to hold AsciiDoc-based excerpts
- fire pre_render and post_render hooks when converting AsciiDoc-based excerpt
- patch to_liquid method on excerpt in Jekyll 3.0 
- add tests