### PR TITLE
Add support for "unpublished" site config in Jekyll

### DIFF
--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -192,6 +192,11 @@ module Jekyll
           if (layout_attr = resolve_default_layout document, opts[:attributes])
             opts[:attributes] = opts[:attributes].merge layout_attr
           end
+          if document.site.config['unpublished']
+            opts[:attributes] = opts[:attributes].merge(
+              %(#{@asciidoc_config['page_attribute_prefix']}published) => true
+            )
+          end
           # NOTE return instance even if header is empty since attributes may be inherited from config
           doc = ::Asciidoctor.load header, opts
         else

--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -103,7 +103,7 @@ module Jekyll
 
         document.extend Document
         document.extend NoLiquid unless data['liquid']
-        (data.fetch 'published', true) || document.site.config['unpublished']
+        data.fetch 'published', true
       end
 
       def generate_pygments_stylesheet site, attrs

--- a/lib/jekyll-asciidoc/integrator.rb
+++ b/lib/jekyll-asciidoc/integrator.rb
@@ -103,7 +103,7 @@ module Jekyll
 
         document.extend Document
         document.extend NoLiquid unless data['liquid']
-        data.fetch 'published', true
+        (data.fetch 'published', true) || document.site.config['unpublished']
       end
 
       def generate_pygments_stylesheet site, attrs

--- a/spec/fixtures/unpublished_site_config/_config.yml
+++ b/spec/fixtures/unpublished_site_config/_config.yml
@@ -1,0 +1,3 @@
+plugins:
+- jekyll-asciidoc
+unpublished: true

--- a/spec/fixtures/unpublished_site_config/not-published.adoc
+++ b/spec/fixtures/unpublished_site_config/not-published.adoc
@@ -1,0 +1,4 @@
+= Not Published
+:page-published: false
+
+This page should be published only when unpublished config is given.

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -1324,4 +1324,17 @@ describe 'Jekyll::AsciiDoc' do
       (expect aside).not_to include 'Micro Section'
     end
   end
+
+  describe 'unpublished config is set' do
+    use_fixture :unpublished_site_config
+
+    before :each do
+      site.process
+    end
+
+    it 'should publish pages regardless of published page variable if unpublished site config is set' do
+      file = output_file 'not-published.html'
+      (expect ::File).to exist file
+    end
+  end
 end


### PR DESCRIPTION
All pages including unpublished pages (`published: false` is set in AsciiDoc Header) will be generated in either of the following cases:

 * `unpublished: true` is set in `_config.yml`
 * `jekyll serve` or `jekyll build` is executed with the option `--unpublished`

This feature is useful for previewing unpublished pages.

I added a test for it. If this test is needless (or redundant), I will revert it.
