### PR TITLE
Support Rouge as syntax highlighter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1201,7 +1201,9 @@ You need to augment the layout to include resources typically present in a stand
 
 === Stylesheet for Code Highlighting
 
-Asciidoctor integrates with Pygments to provide code highlighting of source blocks in AsciiDoc content.
+Asciidoctor integrates with Pygments and Rouge to provide code highlighting of source blocks in AsciiDoc content.
+
+Rouge is the default highlighter for Jekyll versions 4.0 and later, so it is already installed with Jekyll.
 
 To enable Pygments, you must install the `pygments.rb` gem.
 To do so, add the `pygments.rb` gem to your [.path]_Gemfile_:
@@ -1214,20 +1216,20 @@ gem 'pygments.rb', '~> 1.1.2'
 IMPORTANT: To use Pygments with Ruby >= 2.4 or JRuby, you must install pygments.rb >= 1.1.0.
 
 As part of this integration, Asciidoctor generates a custom stylesheet tailored specially to work with the HTML that Asciidocotor produces.
-Since this stylesheet is backed by the Pygments API, it provides access to all the themes in Pygments
+Since this stylesheet is backed by the Pygments API, it provides access to all the themes in Pygments.
 
-This plugin will automatically generate a stylesheet for Pygments into the source directory if the AsciiDoc attributes in your site's {path-config} are configured as follows:
+This plugin will automatically generate a stylesheet for Pygments or Rouge into the source directory if the AsciiDoc attributes in your site's {path-config} are configured as follows:
 
-* `source-highlighter` has the value `pygments`
-* `pygments-css` has the value `class` or is not set
-* `pygments-stylesheet` is not unset (if set, it can have any value)
+* `source-highlighter` has the value `pygments` or `rouge`
+* `pygments-css` (or `rouge-css`, respectively) has the value `class` or is not set
+* `pygments-stylesheet` (or `rouge-stylesheet`, respectively) is not unset (if set, it can have any value)
 
-By default, the stylesheet is written to `stylesdir` + `pygments-stylesheet`.
-If the `pygments-stylesheet` attribute is not specified, the value defaults to `asciidoc-pygments.css`.
+By default, the stylesheet is written to `stylesdir` + `{pygments,rouge}-stylesheet`, depending on the value of `source-highlighter`.
+If the `pygments-stylesheet` or `rouge-stylesheet` attribute is not specified, the value defaults to `asciidoc-{pygments,rouge}.css`.
 You can customize this value to your liking.
 
-The Pygments theme is selected by the value of the `pygments-style` attribute.
-If this attribute is not set, it defaults to `vs`.
+The theme is selected by the value of the `pygments-style` or `rouge-style` attribute, respectively.
+If this attribute is not set, it defaults to `vs` for Pygments and `github` for Rouge.
 
 The stylesheet file will be created if it does not yet exist or the theme has been changed.
 Jekyll will handle copying the file to the output directory.
@@ -1239,7 +1241,16 @@ You'll need to add a line to your template to link to this stylesheet, such as:
 <link rel="stylesheet" href="{{ "/css/asciidoc-pygments.css" | prepend: site.baseurl }}">
 ----
 
-To disable this feature, either set the `pygments-css` to `style` (to enable inline styles) or unset the `pygments-stylesheet` attribute in your site's {path-config}.
+for Pygments or
+
+[source,html]
+----
+<link rel="stylesheet" href="{{ "/css/asciidoc-rouge.css" | prepend: site.baseurl }}">
+----
+
+or Rouge, respectively.
+
+To disable this feature, either set the `{pygments,rouge}-css` attribute to `style` (to enable inline styles) or unset the `pygments-stylesheet` and `rouge-stylesheet` attributes in your site's {path-config}.
 
 NOTE: It may still be necessary to make some tweaks to your site's stylesheet to accomodate this integration.
 

--- a/spec/fixtures/rouge_code_highlighting/_config.yml
+++ b/spec/fixtures/rouge_code_highlighting/_config.yml
@@ -1,0 +1,6 @@
+plugins:
+- jekyll-asciidoc
+asciidoctor:
+  attributes:
+  - stylesdir=/css
+  - source-highlighter=rouge@

--- a/spec/fixtures/rouge_code_highlighting/_layouts/page.html
+++ b/spec/fixtures/rouge_code_highlighting/_layouts/page.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+<link rel="stylesheet" href="{{ "/css/asciidoc-rouge.css" | prepend: site.baseurl }}">
+</head>
+<body>
+<div class="page-content">
+{{ content }}
+</div>
+</body>
+</html>

--- a/spec/fixtures/rouge_code_highlighting/page-with-code.adoc
+++ b/spec/fixtures/rouge_code_highlighting/page-with-code.adoc
@@ -1,0 +1,16 @@
+= Code
+
+```ruby
+class NilClass
+  alias :nil_or_empty? :nil?
+end
+
+class String
+  def nil_or_empty?
+    alias :nil_or_empty? :empty?
+  end
+end
+
+v = nil
+puts v.nil_or_empty?
+```

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -1244,7 +1244,7 @@ describe 'Jekyll::AsciiDoc' do
         src_content = ::File.read src_file
         out_content = ::File.read out_file
         (expect src_content).to eql out_content
-        (expect src_content).to include '.pygments .tok-c'
+        (expect src_content).to include '.pygments .tok-c' # comment color
       ensure
         if ::File.exist? src_file
           ::File.delete src_file
@@ -1261,7 +1261,57 @@ describe 'Jekyll::AsciiDoc' do
         out_content = ::File.read src_file
         attrs = site.config['asciidoctor'][:attributes]
         attrs['pygments-style'] = 'monokai'
-        integrator.generate_pygments_stylesheet site, attrs
+        integrator.generate_stylesheet 'pygments', site, attrs
+        (expect ::File.read src_file).not_to eql src_content
+        ::Jekyll::StaticFile.reset_cache
+        site.process
+        new_out_content = ::File.read out_file
+        (expect new_out_content).not_to eql out_content
+        (expect new_out_content).to include 'background-color: #49483e'
+      ensure
+        if ::File.exist? src_file
+          ::File.delete src_file
+          ::Dir.rmdir ::File.dirname src_file
+        end
+      end
+    end
+  end
+
+  describe 'rouge code highlighting' do
+    use_fixture :rouge_code_highlighting
+
+    before :each do
+      ::Jekyll::StaticFile.reset_cache
+      site.process
+    end
+
+    it 'should write the rouge stylesheet to the stylesdir' do
+      src_file = source_file 'css/asciidoc-rouge.css'
+      out_file = output_file 'css/asciidoc-rouge.css'
+      begin
+        (expect ::File).to exist src_file
+        (expect ::File).to exist out_file
+        src_content = ::File.read src_file
+        out_content = ::File.read out_file
+        (expect src_content).to eql out_content
+        (expect src_content).to include '.rouge .cm' # comment color
+      ensure
+        if ::File.exist? src_file
+          ::File.delete src_file
+          ::Dir.rmdir ::File.dirname src_file
+        end
+      end
+    end
+
+    it 'should overwrite rouge stylesheet if style has changed' do
+      src_file = source_file 'css/asciidoc-rouge.css'
+      out_file = output_file 'css/asciidoc-rouge.css'
+      begin
+        src_content = ::File.read src_file
+        out_content = ::File.read src_file
+        attrs = site.config['asciidoctor'][:attributes]
+        attrs['rouge-style'] = 'monokai'
+        integrator.generate_stylesheet 'rouge', site, attrs
         (expect ::File.read src_file).not_to eql src_content
         ::Jekyll::StaticFile.reset_cache
         site.process


### PR DESCRIPTION
Commit message:

> Refactors code to be more generic, following the same model/prefixes as with pygments.
> It also calls the Asciidoctor syntax highlighter factory directly, as there are no
> helper methods for rouge in the Stylesheets class in Asciidoctor.
> 
> Closes: #221 

I tested the package locally and it seems to work fine. The tests are a modified copy of the Pygments tests. I am unsure if it is reasonable to have the default value of `{pygments,rouge}-stylesheet` to be highlighter-dependent, as it will make it harder to integrate the Asciidoc plugin into templates, without forcing users to re-define it in every Jekyll configuration; so maybe setting both to `asciidoc-highlighter.css` might be a better choice. What are you thoughts?

Feedback is always welcome! (My Ruby is not that great, yet.)