### PR TITLE
add missing methods to Jekyll::AsciiDoc::Excerpt

### DIFF
--- a/lib/jekyll-asciidoc/excerpt.rb
+++ b/lib/jekyll-asciidoc/excerpt.rb
@@ -44,6 +44,14 @@ module Jekyll
         #::Jekyll::Hooks.trigger collection.label.to_sym, hook_name, self, *args if collection
         ::Jekyll::Hooks.trigger :documents, hook_name, self, *args
       end
+
+      def permalink
+        nil
+      end
+
+      def write?
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
write? and permalink are required by some plugins, like jekyll-jemoji.

so add them accordingly

resolves #230

Signed-off-by: Kefu Chai <tchaikov@gmail.com>