### PR TITLE
Fix nested quotes in pygments stylesheet reference

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1271,7 +1271,7 @@ You'll need to add a line to your template to link to this stylesheet, such as:
 
 [source,html]
 ----
-<link rel="stylesheet" href="{{ "/css/asciidoc-pygments.css" | prepend: site.baseurl }}">
+<link rel="stylesheet" href="{{ '/css/asciidoc-pygments.css' | prepend: site.baseurl }}">
 ----
 
 To disable this feature, either set the `pygments-css` to `style` (to enable inline styles) or unset the `pygments-stylesheet` attribute in your site's {path-config}.


### PR DESCRIPTION
Looks like you've got an issue with nested quotes in the example of linking to a pygments generated stylesheet?