### PR TITLE
resolves #239 broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,10 @@ git:
   depth: 5
 language: ruby
 rvm:
+- 2.7.2
 - 2.5.5
 - 2.4.6
-- 2.3.8
 - jruby-9.2.7.0
-- jruby-9.1.17.0
 matrix:
   include:
   - rvm: &release_rvm 2.6.3
@@ -16,7 +15,7 @@ matrix:
   - rvm: *release_rvm
     env: JEKYLL_VERSION=3.0.0
   - rvm: *release_rvm
-    env: ASCIIDOCTOR_VERSION=1.5.8
+    env: ASCIIDOCTOR_VERSION=2.0.0
 bundler_args: --jobs=3 --retry=3 --without=docs
 script:
 - bundle exec rake spec

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,10 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {url-repo}/commits/master[commit history] on GitHub.
 
+== 3.0.0? @djencks
+
+* Minimum asciidoctor version 2.0, ruby 2.4, jruby 9.2.7. Earlier ruby versions don't seem to be supported on CI infrastructure. (#237)
+
 == 3.0.0.beta.2 (2019-06-03) - @mojavelinux
 
 * allow site-wide AsciiDoc attributes to also be defined on `asciidoc` key in site configuration (#126)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,12 +4,12 @@ clone_depth: 2
 environment:
   matrix:
   # see https://www.appveyor.com/docs/build-environment/#ruby for list of installed Ruby runtimes
+  - ruby_version: '26'
+  - ruby_version: '26-x64'
   - ruby_version: '25'
   - ruby_version: '25-x64'
   - ruby_version: '24'
   - ruby_version: '24-x64'
-  - ruby_version: '23'
-  - ruby_version: '23-x64'
 init:
 - set PATH=C:\Ruby%ruby_version%\bin;%PATH:C:\Ruby193\bin;=%
 - echo %PATH%

--- a/jekyll-asciidoc.gemspec
+++ b/jekyll-asciidoc.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'asciidoctor', '>= 1.5.0'
+  s.add_runtime_dependency 'asciidoctor', '~> 2.0'
   s.add_runtime_dependency 'jekyll', '>= 3.0.0'
 
   s.add_development_dependency 'deep-cover-core', '~> 0.7.0'

--- a/spec/fixtures/include_relative_to_root/_config.yml
+++ b/spec/fixtures/include_relative_to_root/_config.yml
@@ -1,2 +1,3 @@
+source: source
 plugins:
   - jekyll-asciidoc

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.before :each do
+    (expect ::File.exist? source_dir(::File.join(name.to_s, '_config.yml'))).to be_truthy
+  end
+
   def use_fixture name
     let (:name) { name.to_s }
   end


### PR DESCRIPTION
moved the `include_relative_to_root` fixture _config.yml to the expected location at root.
Added a check that there is a _config.yml at root of each fixture.