### PR TITLE
Restore earliest ruby version for released 3.0 to 2.3.0

### DIFF
--- a/docs/modules/ROOT/pages/installation.adoc
+++ b/docs/modules/ROOT/pages/installation.adoc
@@ -2,7 +2,7 @@
 
 == Prerequisites
 
-To use this plugin, you must be using Jekyll >= 3.0.0 and Ruby >= 2.4.0 (with development headers installed).
+To use this plugin, you must be using Jekyll >= 3.0.0 and Ruby >= 2.3.0 (with development headers installed).
 You should also be familiar with creating sites with Jekyll.
 If you're not, you should first read the {url-jekyll-docs}[Jekyll documentation] to familiarize yourself with how it works.
 Experience with AsciiDoc and Asciidoctor is also helpful, but not a requirement.


### PR DESCRIPTION
We're now only able to test ruby 2.4.x, but when 3.0 was released apparently testing on 2.3.0 also worked, so document that.