### PR TITLE
resolves #164: implement docinfo support

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,7 +5,7 @@
 This document provides a high-level view of the changes to the {project-name} by release.
 For a detailed view of what has changed, refer to the {url-repo}/commits/master[commit history] on GitHub.
 
-== 3.0.0? @djencks
+== 3.1.0 @djencks
 
 * Convert documentation from README.adoc to an Antora component in the Asciidoctor docs site. (#238)
 * Minimum asciidoctor version 2.0, ruby 2.4, jruby 9.2.7. Earlier ruby versions don't seem to be supported on CI infrastructure. (#237)

--- a/docs/modules/ROOT/pages/liquid-filters.adoc
+++ b/docs/modules/ROOT/pages/liquid-filters.adoc
@@ -1,7 +1,7 @@
 = Working with AsciiDoc Content in Templates
 
 Jekyll uses the Liquid templating language to process templates.
-This plugin defines two additional Liquid filters, `asciidocify` and `tocify_asciidoc`, for working with AsciiDoc content in those templates.
+This plugin defines three additional Liquid filters, `asciidocify`, `tocify_asciidoc`, and `asciidoc_docinfo`, for working with AsciiDoc content in those templates.
 
 == Converting a String from AsciiDoc
 
@@ -25,7 +25,7 @@ If the content represents a single paragraph, and you only want to perform inlin
 
 == Generating a Table of Contents
 
-Since version 2.1.0 of this plugin, you can use the `tocify_asciidoc` filter to generate a table of contents from the content of any page that is generated from AsciiDoc.
+The `tocify_asciidoc` filter generates a table of contents from the content of any page that is generated from AsciiDoc.
 This filter gives you the ability to place this table of contents anywhere inside the page layout, but outside the main content.
 
 You apply the `tocify_asciidoc` filter to `page.document`, the page variable that resolves to the parsed AsciiDoc document, as shown here:
@@ -72,3 +72,57 @@ It's possible to conditionally disable this by using a Liquid `if` statement in 
 Then in the front matter of pages where you do not want a table of contents to appear, use the attribute `:page-show-toc: false`.
 Note that since this example uses a custom attribute, its name can be anything you'd like, it only needs to start with with `page-`.
 If you change the attribute name from this example, be sure to update the it in the `if` statement as appropriate.
+
+== Incorporating DocInfo content into layout templates
+
+The `asciidoc_docinfo` filter will insert the docinfo for a location into the template.
+The content may be from xref:asciidoctor::docinfo.adoc[docinfo files] or from xref:asciidoctor:extensions:processors/docinfo-processor.adoc[docinfo extensions].
+The Asciidoctor html5 converter supports three standard location names:
+
+`head`::
+  Content, typically comprised of `meta` tags and scripts, that goes at the end of the `head` tag.
+`header`::
+  Content that goes immediately before the body.
+In the standard Asciidoctor page this is most useful for replacing the `header` tag, together with the `noheader` attribute.
+`footer`::
+  Content that goes immediately after the standard footer.
+In the standard Asciidoctor page this can be used to replace the footer by setting the attribute `nofooter`.
+
+Bear this in mind when using pre-existing docinfo files or extensions intended for use with standard Asciidoctor.
+
+In `jekyll-asciidoc`, there are no limitations on the location name.
+However, if you use non-standard locations, or violate the expectations for the standard location content, your docinfo files or extensions will not be useable elsewhere.
+
+To place docinfo head content in a template:
+
+----
+{{ page.document | asciidoc_docinfo }}
+----
+
+For header content:
+
+----
+{{ page.document | asciidoc_docinfo: "header" }}
+----
+
+For footer content:
+
+----
+{{ page.document | asciidoc_docinfo: "footer" }}
+----
+
+For a non-standard location:
+
+----
+{{ page.document | asciidoc_docinfo: "custom" }}
+----
+
+In this case a docinfo file for all pages would be named `docinfo-custom.html`.
+
+=== Locating docinfo files
+
+By default, all docinfo files are looked up in `base_dir` which if not configured is the current working directory.
+Consult xref:base-dir.adoc[] for ways to configure `base_dir`.
+
+Beyond configuring `base_dir`, if the asciidoctor attribute `docinfodir` is set globally in `_config.yml` or in a document header, docinfo files will be looked up in that location, resolved relative to `base_dir`.
+

--- a/lib/jekyll-asciidoc/filters.rb
+++ b/lib/jekyll-asciidoc/filters.rb
@@ -30,6 +30,24 @@ module Jekyll
         ::Asciidoctor::Document === document ?
           (document.converter.convert document, 'outline', toclevels: (levels.nil_or_empty? ? nil : levels.to_i)) : nil
       end
+
+      # A Liquid filter for accessing docinfo from Asciidoctor.
+      #
+      # @param document [Asciidoctor::Document] the parsed AsciiDoc document.
+      # @param location [Symbol] "head" (default), "header" or "footer" are the standard locations for html.
+      #   In the built-in Asciidoctor converter, "head" content is inserted just before the closing </head> tag.
+      #   "header" content is inserted just before the default <header> tag (if used), and
+      #   "footer" content is inserted just after the default <footer> tag (if used).
+      #   In jekyll layouts, you can use any location you want, and insert it anywhere you want.
+      #   Consult the Asciidoctor documentation for how to configure the docinfo and docinfodir attributes
+      #   so that your docinfo files will be found, and the Asciidoctor extensions documentation for docinfo processors.
+      # @param suffix [String] The suffix of the docinfo file(s). If not set, the extension
+      #           will be set to the outfilesuffix. (default: nil)
+      # @return [String] the docinfo text for the specified location.
+      def asciidoc_docinfo document, location = :head, suffix = nil
+        ::Asciidoctor::Document === document ?
+          (document.docinfo location.to_sym, suffix) : nil
+      end
     end
 
     ::Liquid::Template.register_filter Filters

--- a/spec/fixtures/docinfo_filter/_config.yml
+++ b/spec/fixtures/docinfo_filter/_config.yml
@@ -1,0 +1,5 @@
+plugins:
+- jekyll-asciidoc
+asciidoctor:
+  base_dir: :source
+#  base_dir: spec

--- a/spec/fixtures/docinfo_filter/_layouts/default.html
+++ b/spec/fixtures/docinfo_filter/_layouts/default.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{{ page.title }}</title>
+{{ page.document | asciidoc_docinfo }}
+</head>
+{{ page.document | asciidoc_docinfo: "header" }}
+<body>
+<div class="page-content">
+{{ content }}
+</div>
+{{ page.document | asciidoc_docinfo: "custom" }}
+</body>
+{{ page.document | asciidoc_docinfo: "footer" }}
+</html>

--- a/spec/fixtures/docinfo_filter/docinfo-custom.html
+++ b/spec/fixtures/docinfo_filter/docinfo-custom.html
@@ -1,0 +1,1 @@
+<div class="custom">this is custom</div>

--- a/spec/fixtures/docinfo_filter/docinfo-footer.html
+++ b/spec/fixtures/docinfo_filter/docinfo-footer.html
@@ -1,0 +1,1 @@
+<footer>this is the footer</footer>

--- a/spec/fixtures/docinfo_filter/docinfo-header.html
+++ b/spec/fixtures/docinfo_filter/docinfo-header.html
@@ -1,0 +1,1 @@
+<header>this is the header</header>

--- a/spec/fixtures/docinfo_filter/docinfo.html
+++ b/spec/fixtures/docinfo_filter/docinfo.html
@@ -1,0 +1,1 @@
+<div>this is the head</div>

--- a/spec/fixtures/docinfo_filter/index.adoc
+++ b/spec/fixtures/docinfo_filter/index.adoc
@@ -1,0 +1,7 @@
+= Page Title
+:docinfo: shared
+//:docinfodir: spec/fixtures/docinfo_filter
+
+== Major Section A
+
+content

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -1324,4 +1324,23 @@ describe 'Jekyll::AsciiDoc' do
       (expect aside).not_to include 'Micro Section'
     end
   end
+
+  describe 'docinfo filter' do
+    use_fixture :docinfo_filter
+
+    before :each do
+      site.process
+    end
+
+    it 'should include docinfo content when docinfo filter is applied to page.document' do
+      file = output_file 'index.html'
+      (expect ::File).to exist file
+      contents = ::File.read file
+      head = (contents.match %r/<head>.*<\/head>/m)[0]
+      (expect head).to include '<div>this is the head</div>'
+      (expect header_loc = contents.index('<header>this is the header</header>')).to be > contents.index(head)
+      (expect custom_loc = contents.index('<div class="custom">this is custom</div>')).to be > header_loc
+      (expect contents.index('<footer>this is the footer</footer>')).to be > custom_loc
+    end
+  end
 end

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -2,7 +2,7 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new :spec do |t|
     t.verbose = true
-    rspec_opts = %W[-f progress #{Random.rand 1000}]
+    rspec_opts = %W[-f progress --seed #{Random.rand 1000}]
     rspec_opts.unshift '-w' if !ENV['CI'] || ENV['COVERAGE']
     t.rspec_opts = rspec_opts
   end

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -2,7 +2,7 @@ begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new :spec do |t|
     t.verbose = true
-    rspec_opts = %W[-f progress --seed #{Random.rand 1000}]
+    rspec_opts = %W[-f progress #{Random.rand 1000}]
     rspec_opts.unshift '-w' if !ENV['CI'] || ENV['COVERAGE']
     t.rspec_opts = rspec_opts
   end


### PR DESCRIPTION
This introduces a liquid filter that inserts docinfo from the Asciidoctor docinfo mechanism.  Not only the standard head, header, and footer locations are supported, but also any custom location. See the included documentation for details.