### PR TITLE
resolves #230: claim an excerpt is an excerpt,

### DIFF
--- a/jekyll-asciidoc.gemspec
+++ b/jekyll-asciidoc.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jekyll', '>= 3.0.0'
 
   s.add_development_dependency 'deep-cover-core', '~> 0.7.0'
+  s.add_development_dependency 'jekyll-mentions', '~> 1.6.0'
   s.add_development_dependency 'pygments.rb', '~> 1.2.1'
   s.add_development_dependency 'rake', '~> 12.3.2'
   s.add_development_dependency 'rspec', '~> 3.8.0'

--- a/lib/jekyll-asciidoc/converter.rb
+++ b/lib/jekyll-asciidoc/converter.rb
@@ -140,6 +140,10 @@ module Jekyll
         '.html'
       end
 
+      Jekyll::Hooks.register :excerpts, :pre_render do |excerpt, payload|
+        before_render excerpt, payload
+      end
+
       def self.before_render document, payload
         (get_instance document.site).before_render document, payload if Document === document || Excerpt === document
       end

--- a/lib/jekyll-asciidoc/excerpt.rb
+++ b/lib/jekyll-asciidoc/excerpt.rb
@@ -41,8 +41,7 @@ module Jekyll
       alias to_liquid data if Jekyll3_0
 
       def trigger_hooks hook_name, *args
-        #::Jekyll::Hooks.trigger collection.label.to_sym, hook_name, self, *args if collection
-        ::Jekyll::Hooks.trigger :documents, hook_name, self, *args
+        ::Jekyll::Hooks.trigger :excerpts, hook_name, self, *args
       end
     end
   end

--- a/spec/fixtures/posts_with_excerpts/_config.yml
+++ b/spec/fixtures/posts_with_excerpts/_config.yml
@@ -1,2 +1,3 @@
 plugins:
 - jekyll-asciidoc
+- jekyll-mentions

--- a/spec/fixtures/posts_with_excerpts/plain/_config.yml
+++ b/spec/fixtures/posts_with_excerpts/plain/_config.yml
@@ -1,0 +1,4 @@
+source: ./..
+
+plugins:
+- jekyll-asciidoc

--- a/spec/fixtures/posts_with_excerpts/with_plugin/_config.yml
+++ b/spec/fixtures/posts_with_excerpts/with_plugin/_config.yml
@@ -1,3 +1,4 @@
 plugins:
 - jekyll-asciidoc
 - jekyll-mentions
+source: ..

--- a/spec/jekyll-asciidoc_spec.rb
+++ b/spec/jekyll-asciidoc_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe 'Jekyll::AsciiDoc' do
   let :config do
-    ::Jekyll.configuration fixture_site_params name
+    ::Jekyll.configuration fixture_site_params(name, config_path)
   end
 
   let :site do
@@ -921,103 +921,105 @@ describe 'Jekyll::AsciiDoc' do
   end
 
   describe 'posts with excerpts' do
-    use_fixture :posts_with_excerpts
+    [:plain, :with_plugin].each do |config_path|
+      use_fixture :posts_with_excerpts, config_path
 
-    before :each do
-      site.process
-    end
+      before :each do
+        site.process
+      end
 
-    it 'should use page contents as excerpt if excerpt separator not found after AsciiDoc header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="header-and-single-paragraph">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the excerpt and body text.</p>'
-    end
+      it 'should use page contents as excerpt if excerpt separator not found after AsciiDoc header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="header-and-single-paragraph">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the excerpt and body text.</p>'
+      end
 
-    it 'should use first paragraph as excerpt if excerpt separator is found after AsciiDoc header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="header-and-multiple-paragraphs">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the excerpt.</p>'
-      (expect $1).not_to include '<p>This is the rest of the body text that comes after the excerpt.</p>'
-    end
+      it 'should use first paragraph as excerpt if excerpt separator is found after AsciiDoc header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="header-and-multiple-paragraphs">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the excerpt.</p>'
+        (expect $1).not_to include '<p>This is the rest of the body text that comes after the excerpt.</p>'
+      end
 
-    it 'should use page contents as excerpt if excerpt separator not found with no AsciiDoc header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="single-paragraph-only">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the excerpt and body text.</p>'
-    end
+      it 'should use page contents as excerpt if excerpt separator not found with no AsciiDoc header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="single-paragraph-only">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the excerpt and body text.</p>'
+      end
 
-    it 'should use first paragraph as excerpt if excerpt separator is found with no AsciiDoc header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="multiple-paragraphs-only">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
-      (expect $1).not_to include '<p>This is the rest of the body text that comes after the excerpt.</p>'
-    end
+      it 'should use first paragraph as excerpt if excerpt separator is found with no AsciiDoc header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="multiple-paragraphs-only">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
+        (expect $1).not_to include '<p>This is the rest of the body text that comes after the excerpt.</p>'
+      end
 
-    it 'should use excerpt defined as page attribute in AsciiDoc header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="excerpt-in-header">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
-      (expect $1).not_to include '<p>This is the first paragraph, but not the excerpt.</p>'
-    end
+      it 'should use excerpt defined as page attribute in AsciiDoc header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="excerpt-in-header">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
+        (expect $1).not_to include '<p>This is the first paragraph, but not the excerpt.</p>'
+      end
 
-    it 'should use excerpt defined in front matter' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="excerpt-in-front-matter">(.*?)<\/li>/m
-      (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
-      (expect $1).not_to include '<p>This is the first paragraph, but not the excerpt.</p>'
-    end
+      it 'should use excerpt defined in front matter' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="excerpt-in-front-matter">(.*?)<\/li>/m
+        (expect $1).to include '<p>This is the <em>excerpt</em>.</p>'
+        (expect $1).not_to include '<p>This is the first paragraph, but not the excerpt.</p>'
+      end
 
-    it 'should set excerpt to blank if excerpt_separator is blank' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="blank-excerpt">(.*?)<\/li>/m
-      (expect $1).to include '<p class="excerpt"></p>'
-    end
+      it 'should set excerpt to blank if excerpt_separator is blank' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="blank-excerpt">(.*?)<\/li>/m
+        (expect $1).to include '<p class="excerpt"></p>'
+      end
 
-    it 'should set excerpt to blank if document only has a header' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="header-only">(.*?)<\/li>/m
-      (expect $1).to include '<p class="excerpt"></p>'
-    end
+      it 'should set excerpt to blank if document only has a header' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="header-only">(.*?)<\/li>/m
+        (expect $1).to include '<p class="excerpt"></p>'
+      end
 
-    it 'should not process liquid in excerpt by default' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="no-liquid">(.*?)<\/li>/m
-      (expect $1).to include '<p>{{ page.title }}</p>'
-    end
+      it 'should not process liquid in excerpt by default' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="no-liquid">(.*?)<\/li>/m
+        (expect $1).to include '<p>{{ page.title }}</p>'
+      end
 
-    it 'should process liquid in excerpt if liquid page variable is set' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="with-liquid">(.*?)<\/li>/m
-      (expect $1).to include '<p>With Liquid</p>'
-    end
+      it 'should process liquid in excerpt if liquid page variable is set' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="with-liquid">(.*?)<\/li>/m
+        (expect $1).to include '<p>With Liquid</p>'
+      end
 
-    it 'should extract excerpt correctly even when post uses standalone layout' do
-      file = output_file 'index.html'
-      (expect ::File).to exist file
-      contents = ::File.read file
-      contents =~ %r/<li data-slug="standalone-layout">(.*?)<\/li>/m
-      (expect $1).to include '<p>Excerpt of post with standalone layout.</p>'
-      (expect $1).not_to include '<p>This is not part of the excerpt.</p>'
+      it 'should extract excerpt correctly even when post uses standalone layout' do
+        file = output_file 'index.html'
+        (expect ::File).to exist file
+        contents = ::File.read file
+        contents =~ %r/<li data-slug="standalone-layout">(.*?)<\/li>/m
+        (expect $1).to include '<p>Excerpt of post with standalone layout.</p>'
+        (expect $1).not_to include '<p>This is not part of the excerpt.</p>'
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,18 +36,20 @@ RSpec.configure do |config|
   end
 
   config.before :each do
-    (expect ::File.exist? source_dir(::File.join(name.to_s, '_config.yml'))).to be_truthy
+    (expect ::File.exist? source_dir(::File.join(name.to_s, config_path.to_s, '_config.yml'))).to be_truthy
   end
 
-  def use_fixture name
+  def use_fixture name, config_path = ''
     let (:name) { name.to_s }
+    let (:config_path) { (config_path || '').to_s }
   end
 
-  def fixture_site_params path
+  def fixture_site_params path, config_path = ''
     {
       'source' => (source_dir path),
       'destination' => (output_dir path),
       'url' => 'http://example.org',
+      config_path && 'config' => ::File.join((source_dir path), config_path, '_config.yml'),
     }
   end
 


### PR DESCRIPTION
 and register a before_render hook for it.

All tests pass with this, with one of the problematic additional plugins registered (jekyll-mentions) for the excerpt tests.
Is there anything else to look out for? Other events/hooks?
Is unconditionally adding the additional plugin for the excerpt tests reasonable?