### PR TITLE
Document yaml escaping and continuations for attributes (#158) [skip ci]

### DIFF
--- a/docs/modules/ROOT/pages/global-page-attributes.adoc
+++ b/docs/modules/ROOT/pages/global-page-attributes.adoc
@@ -90,3 +90,30 @@ asciidoctor:
     -idprefix:
 ----
 
+== Yaml expressions as global attribute values
+
+Jekyll parses the entire `_config.yml` file as yaml, so by default any attribute values that happen to be yaml expressions will be converted to objects.
+The object will be rendered using the Ruby `.to_s` method.
+To preserve the original string, quote the value:
+
+[source,yaml]
+----
+asciidoctor:
+  attributes:
+    page-yaml: {key1: foo, key2: bar} # <1>
+    page-yaml-string: '{key1: foo, key2: bar}' #<2>
+    page-yaml-multiline: | #<3>
+      key1: foo
+      key2: bar
+----
+<1> Unquoted value will render as `{"key1"=>"foo", "key2"=>"bar"}`, the string representation of the Ruby object.
+<2> Quoted value can be used as a string valued Asciidoc page attribute, rendering as the original string, `{key1: foo, key2: bar}`.
+If it is also used in liquid templates, the yaml will be parsed to an object before being made available to the liquid template.
+<3> Multi-line attributes cannot be defined in an AsciiDoc document, but this shows a way to set a global multi-line valued attribute. This will be rendered as:
+
+....
+key1: foo
+key2: bar
+....
+
+Note that all leading spaces are removed.

--- a/docs/modules/ROOT/pages/page-attributes.adoc
+++ b/docs/modules/ROOT/pages/page-attributes.adoc
@@ -12,6 +12,21 @@ For example, here's how you can assign a value to the `page.header.image` page v
 :page-header: { image: logo.png }
 ----
 
+For longer expressions that are inconvenient to write on one line, line continuations may be used:
+[source,asciidoc]
+----
+:page-complex-object: { data: \
+  { detail: \
+    {subdetail: \
+      [ item1, \
+       item2] \
+    } \
+  } \
+}
+
+----
+Note that this is still in yaml single-line syntax.
+
 To define a page attribute name that contains multiple words, use either a hyphen or underscore character to connect the words.
 
 [source,asciidoc]


### PR DESCRIPTION
This documents existing behavior.